### PR TITLE
Add transitive instances

### DIFF
--- a/Mtl/Data/ErrorT.juvix
+++ b/Mtl/Data/ErrorT.juvix
@@ -1,12 +1,17 @@
 module Mtl.Data.ErrorT;
 
 import Mtl.Trait.Error open;
+import Mtl.Trait.State open;
+import Mtl.Trait.Reader open;
 import Stdlib.Prelude open;
 
 type ErrorT (Err : Type) (M : Type → Type) (A : Type) :=
   mkErrorT@{
     runErrorT : M (Result Err A);
   };
+
+runError {Err A} {M : Type -> Type} : ErrorT Err M A -> M (Result Err A) :=
+  ErrorT.runErrorT;
 
 instance
 ErrorT-Functor
@@ -49,10 +54,10 @@ ErrorT-Monad
       {A B} (x : ErrorT Err M A) (f : A -> ErrorT Err M B) : ErrorT Err M B :=
       mkErrorT
         do {
-          a <- ErrorT.runErrorT x;
+          a <- runError x;
           case a of {
             | error e := pure (error e)
-            | ok r := ErrorT.runErrorT (f r)
+            | ok r := runError (f r)
           };
         };
   };
@@ -64,5 +69,25 @@ ErrorT-Error
     throw {A} (err : Err) : ErrorT Err M A := mkErrorT (pure (error err));
   };
 
-runError {Err A} {M : Type -> Type} : ErrorT Err M A -> M (Result Err A)
-  | (mkErrorT x) := x;
+instance
+ErrorT-State
+  {E S : Type}
+  {M : Type → Type}
+  {{Monad M}}
+  {{State S M}}
+  : State S (ErrorT E M) :=
+  mkState@{
+    state {A : Type} (f : S -> Pair A S) : ErrorT E M A :=
+      mkErrorT (ok <$> State.state f);
+  };
+
+instance
+ErrorT-Reader
+  {E R : Type}
+  {M : Type → Type}
+  {{Monad M}}
+  {{Reader R M}}
+  : Reader R (ErrorT E M) :=
+  mkReader@{
+    ask : ErrorT E M R := mkErrorT (ok <$> Reader.ask);
+  };

--- a/Mtl/Data/ReaderT.juvix
+++ b/Mtl/Data/ReaderT.juvix
@@ -90,5 +90,6 @@ ReaderT-Error
   {{Error E M}}
   : Error E (ReaderT R M) :=
   mkError@{
-    throw {A : Type} (err : E) : ReaderT R M A := mkReaderT \{_ := Error.throw err}
+    throw {A : Type} (err : E) : ReaderT R M A :=
+      mkReaderT \{_ := Error.throw err};
   };

--- a/Mtl/Data/ReaderT.juvix
+++ b/Mtl/Data/ReaderT.juvix
@@ -1,10 +1,10 @@
 module Mtl.Data.ReaderT;
 
 import Stdlib.Prelude open;
+import Mtl.Trait.Reader open;
+import Mtl.Trait.Error open;
+import Mtl.Trait.State open;
 import Mtl.Trait.MonadTransformer open;
-import Mtl.Trait.MonadTransformer open using {
-  module MonadTransformer as MMonadTransformer;
-};
 
 type ReaderT (S : Type) (M : Type → Type) (A : Type) :=
   mkReaderT@{
@@ -53,24 +53,12 @@ ReaderT-Monad
           }};
   };
 
-import Mtl.Trait.Reader open;
-import Mtl.Trait.Error open;
-import Mtl.Trait.Error open using {module Error as MError};
-import Mtl.Trait.Reader open using {module Reader as MReader};
-import Stdlib.Data.Unit open;
-import Stdlib.Function open;
-
 instance
 ReaderT-Reader
   {S : Type} {M : Type → Type} {{Monad M}} : Reader S (ReaderT S M) :=
   mkReader@{
     ask : ReaderT S M S := mkReaderT λ{s := Applicative.pure s};
   };
-
-import Mtl.Trait.State open;
-import Mtl.Data.StateT open;
-import Mtl.Data.Identity open;
-import Stdlib.Data.Pair open;
 
 liftReaderT {R A : Type} {M : Type → Type} (m : M A) : ReaderT R M A :=
   mkReaderT (const m);
@@ -82,11 +70,25 @@ ReaderT-MonadTransformer {R : Type} : MonadTransformer (ReaderT R) :=
       liftReaderT x;
   };
 
-liftStateT
-  {S A : Type} {M : Type → Type} {{Monad M}} (m : M A) : StateT S M A :=
-  mkStateT
-    λ{s :=
-      do {
-        a <- m;
-        Applicative.pure (a, s);
-      }};
+instance
+ReaderT-State
+  {R S : Type}
+  {M : Type → Type}
+  {{Monad M}}
+  {{State S M}}
+  : State S (ReaderT R M) :=
+  mkState@{
+    state {A : Type} (f : S -> Pair A S) : ReaderT R M A :=
+      mkReaderT \{_ := State.state f};
+  };
+
+instance
+ReaderT-Error
+  {R E : Type}
+  {M : Type → Type}
+  {{Monad M}}
+  {{Error E M}}
+  : Error E (ReaderT R M) :=
+  mkError@{
+    throw {A : Type} (err : E) : ReaderT R M A := mkReaderT \{_ := Error.throw err}
+  };

--- a/Mtl/Data/StateT.juvix
+++ b/Mtl/Data/StateT.juvix
@@ -23,13 +23,6 @@ evalState
   (m : StateT S M A)
   : M A := Functor.map fst (runState s m);
 
-state
-  {A S}
-  {M : Type -> Type}
-  {{Applicative M}}
-  (f : S -> Pair A S)
-  : StateT S M A := mkStateT \{s := pure (f s)};
-
 instance
 StateT-Functor
   {S : Type} {M : Type → Type} {{func : Functor M}} : Functor (StateT S M) :=
@@ -71,8 +64,7 @@ StateT-Monad
 instance
 StateT-State {S : Type} {M : Type → Type} {{Monad M}} : State S (StateT S M) :=
   mkState@{
-    get : StateT S M S := mkStateT λ{s := pure (s, s)};
-    put (s : S) : StateT S M Unit := mkStateT λ{_ := pure (unit, s)};
+    state {A : Type} (f : S -> Pair A S) : StateT S M A := mkStateT (f >> pure)
   };
 
 instance

--- a/Mtl/Data/StateT.juvix
+++ b/Mtl/Data/StateT.juvix
@@ -2,6 +2,8 @@ module Mtl.Data.StateT;
 
 import Stdlib.Prelude open;
 import Mtl.Trait.State open;
+import Mtl.Trait.Reader open;
+import Mtl.Trait.Error open;
 import Mtl.Trait.MonadTransformer open;
 
 type StateT (S : Type) (M : Type → Type) (A : Type) :=
@@ -26,7 +28,7 @@ state
   {M : Type -> Type}
   {{Applicative M}}
   (f : S -> Pair A S)
-  : StateT S M A := mkStateT \{s := Applicative.pure (f s)};
+  : StateT S M A := mkStateT \{s := pure (f s)};
 
 instance
 StateT-Functor
@@ -69,14 +71,52 @@ StateT-Monad
 instance
 StateT-State {S : Type} {M : Type → Type} {{Monad M}} : State S (StateT S M) :=
   mkState@{
-    get : StateT S M S := mkStateT λ{s := Applicative.pure (s, s)};
-    put (s : S) : StateT S M Unit :=
-      mkStateT λ{_ := Applicative.pure (unit, s)};
+    get : StateT S M S := mkStateT λ{s := pure (s, s)};
+    put (s : S) : StateT S M Unit := mkStateT λ{_ := pure (unit, s)};
   };
 
 instance
 StateT-MonadTransformer {S : Type} : MonadTransformer (StateT S) :=
   mkMonadTransformer@{
     lift {A} {M : Type -> Type} {{Monad M}} (m : M A) : StateT S M A :=
-      mkStateT \{s := map \{a := a, s} m};
+      mkStateT
+        \{s :=
+          do {
+            a <- m;
+            pure (a, s);
+          }};
+  };
+
+instance
+StateT-Reader
+  {R S : Type}
+  {M : Type → Type}
+  {{Monad M}}
+  {{Reader R M}}
+  : Reader R (StateT S M) :=
+  mkReader@{
+    ask : StateT S M R :=
+      mkStateT
+        \{s :=
+          do {
+            r <- Reader.ask;
+            pure (r, s);
+          }};
+  };
+
+instance
+StateT-Except
+  {E S : Type}
+  {M : Type → Type}
+  {{Monad M}}
+  {{Error E M}}
+  : Error E (StateT S M) :=
+  mkError@{
+    throw {A} (err : E) : StateT S M A :=
+      mkStateT
+        \{s :=
+          do {
+            a <- Error.throw err;
+            pure (a, s);
+          }};
   };

--- a/Mtl/Data/StateT.juvix
+++ b/Mtl/Data/StateT.juvix
@@ -64,7 +64,7 @@ StateT-Monad
 instance
 StateT-State {S : Type} {M : Type → Type} {{Monad M}} : State S (StateT S M) :=
   mkState@{
-    state {A : Type} (f : S -> Pair A S) : StateT S M A := mkStateT (f >> pure)
+    state {A : Type} (f : S -> Pair A S) : StateT S M A := mkStateT (f >> pure);
   };
 
 instance

--- a/Mtl/Trait/State.juvix
+++ b/Mtl/Trait/State.juvix
@@ -5,11 +5,16 @@ import Stdlib.Prelude open;
 trait
 type State (S : Type) (M : Type -> Type) :=
   mkState@{
-    get : M S;
-    put : S -> M Unit;
+    state : {A : Type} -> (S -> Pair A S) -> M A;
   };
 
 open State public;
+
+get {S} {M : Type -> Type} {{Monad M}} {{State S M}} : M S :=
+  state \{s := s, s};
+
+put {S} {M : Type -> Type} {{Monad M}} {{State S M}} (s : S) : M Unit :=
+  state \{_ := unit, s};
 
 modify
   {S : Type} {M : Type → Type} {{Monad M}} {{State S M}} (f : S → S) : M Unit :=


### PR DESCRIPTION
Add the following instances:
- Reader and State for ErrorT
- Reader and Error for StateT
- State and Error for ReaderT

Also:
1. The state trait has only one primitive method, `state`. So `get` and `put` are now derived from it.